### PR TITLE
Filter pattern url should be the URI without context path

### DIFF
--- a/src/main/java/com/navercorp/lucy/security/xss/servletfilter/XssEscapeServletFilterWrapper.java
+++ b/src/main/java/com/navercorp/lucy/security/xss/servletfilter/XssEscapeServletFilterWrapper.java
@@ -34,7 +34,9 @@ public class XssEscapeServletFilterWrapper extends HttpServletRequestWrapper {
 	public XssEscapeServletFilterWrapper(ServletRequest request, XssEscapeFilter xssEscapeFilter) {
 		super((HttpServletRequest)request);
 		this.xssEscapeFilter = xssEscapeFilter;
-		this.path = ((HttpServletRequest)request).getRequestURI();
+
+		String contextPath = ((HttpServletRequest) request).getContextPath();
+		this.path = ((HttpServletRequest) request).getRequestURI().substring(contextPath.length());
 	}
 
 	@Override


### PR DESCRIPTION
- Context path 유무에 관계없이 filter pattern url에 명시된 경로에 대하여 xss escape 치환합니다.
- https://github.com/naver/lucy-xss-servlet-filter/issues/17 이슈의 개선입니다.